### PR TITLE
feat: game lobbies rounds rework

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -1,12 +1,15 @@
+use crate::game::bid_round::BidRound;
 use crate::user::User;
 use crate::game::lobby::Lobby;
+use crate::game::table::Table;
 
-mod lobby;
-mod table;
+pub mod lobby;
+pub mod table;
+pub mod bid_round;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-struct Settings {
-    to_win: u8,
+pub struct Settings {
+    pub to_win: u8,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -41,39 +44,50 @@ impl<'a> Player<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-struct Game {
+pub struct Game<'a> {
     settings: Settings,
+    table: Table<'a>,
 }
 
-impl Game {
-    fn new(settings: Settings) -> Lobby<'static> {
-        Lobby { settings, players: Vec::new() }
+impl Game<'_> {
+    pub fn new(settings: Settings, table: Table) -> Game {
+        Game { settings, table }
     }
-}
 
-#[derive(Debug, PartialEq, Eq)]
-struct BidRound {
-    settings: Settings,
-    players: Vec<Player<'static>>,
-}
-
-impl BidRound {
-    fn new(settings: Settings) -> BidRound {
-        // TODO(2024-05-25 mollemoll): move players
-        BidRound {  settings, players: Vec::new() }
+    pub fn start_round(&self) -> BidRound {
+        BidRound::new(0)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::game::bid_round::BidRound;
     use super::*;
 
-    #[test]
-    fn new_game_returns_a_lobby() {
-        let settings = Settings { to_win: 13 };
-        let game = Game::new(settings);
+    fn setup_users() -> Vec<User> {
+        vec![
+            User::new("A"),
+            User::new("B"),
+            User::new("C"),
+            User::new("D"),
+        ]
+    }
 
-        assert_eq!(game, Lobby { settings, players: Vec::new() });
+    fn setup_lobby() -> Lobby<'static> {
+        let settings = Settings { to_win: 13 };
+        Lobby::new(settings)
+    }
+
+    #[test]
+    fn new_game() {
+        let settings = Settings { to_win: 13 };
+        let users = setup_users();
+        let mut lobby = setup_lobby();
+        users.iter().for_each(|u| lobby.add_user(u));
+        let table = Table::new(&lobby);
+        let game = Game::new(settings, table);
+
+        assert_eq!(game, Game { settings, table });
     }
 
     #[test]
@@ -83,5 +97,22 @@ mod tests {
 
         assert_eq!(player.user().name(), "John Doe");
         assert_eq!(player.team(), Team::Lajvarna);
+    }
+
+    #[test]
+    fn start_round() {
+        let settings = Settings { to_win: 13 };
+        let users = setup_users();
+        let mut lobby = setup_lobby();
+        users.iter().for_each(|u| lobby.add_user(u));
+        let table = Table::new(&lobby);
+        let game = Game::new(settings, table);
+
+        let bid_round = game.start_round();
+
+        assert_eq!(
+            bid_round.bids().len(),
+            0,
+        );
     }
 }

--- a/src/game/bid_round.rs
+++ b/src/game/bid_round.rs
@@ -1,0 +1,89 @@
+use crate::deck::Deck;
+use crate::hand::Hand;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Bid {
+    Pass,
+    Play,
+}
+
+type WinningBid = Bid;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct BidRound {
+    hands: Vec<Hand>,
+    dealer: usize,
+    bids: Vec<Bid>,
+}
+
+impl BidRound {
+    pub fn new(dealer: usize) -> BidRound {
+        let mut deck = Deck::new();
+        deck.shuffle();
+        let hands = deck.deal_hands();
+
+        BidRound {
+            hands,
+            dealer,
+            bids: Vec::with_capacity(4),
+        }
+    }
+
+    pub fn bids(&self) -> &[Bid] {
+        &self.bids
+    }
+
+    pub fn register_bid(&mut self, bid: Bid) -> Option<WinningBid> {
+        self.bids.push(bid);
+
+        if bid == Bid::Play {
+            return Some(Bid::Play);
+        }
+
+        if self.bids.len() == 4 {
+            return Some(Bid::Pass);
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_bid_round() {
+        let bid_round = BidRound::new(0);
+
+        assert_eq!(bid_round.hands.len(), 4);
+        assert_eq!(bid_round.dealer, 0);
+        assert_eq!(bid_round.bids().len(), 0);
+    }
+
+    #[test]
+    fn register_a_play_bid_triggers_play() {
+        let mut bid_round = BidRound::new(0);
+
+        assert_eq!(bid_round.register_bid(Bid::Play), Some(Bid::Play));
+    }
+
+    #[test]
+    fn register_four_pass_bids_triggers_pass() {
+        let mut bid_round = BidRound::new(0);
+
+        assert_eq!(bid_round.register_bid(Bid::Pass), None);
+        assert_eq!(bid_round.register_bid(Bid::Pass), None);
+        assert_eq!(bid_round.register_bid(Bid::Pass), None);
+        assert_eq!(bid_round.register_bid(Bid::Pass), Some(Bid::Pass));
+    }
+
+    #[test]
+    fn register_three_pass_bids_does_not_trigger_pass() {
+        let mut bid_round = BidRound::new(0);
+
+        assert_eq!(bid_round.register_bid(Bid::Pass), None);
+        assert_eq!(bid_round.register_bid(Bid::Pass), None);
+        assert_eq!(bid_round.register_bid(Bid::Pass), None);
+    }
+}

--- a/src/game/table.rs
+++ b/src/game/table.rs
@@ -3,8 +3,8 @@ use crate::game::lobby::Lobby;
 use crate::game::Player;
 use crate::deck::Deck;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-struct Table<'a> {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Table<'a> {
     north: Player<'a>,
     east: Player<'a>,
     south: Player<'a>,
@@ -12,7 +12,7 @@ struct Table<'a> {
 }
 
 impl<'a> Table<'a> {
-    pub fn new(lobby: Lobby<'a>) -> Table {
+    pub fn new(lobby: &Lobby<'a>) -> Table<'a> {
         // Each player draws a card
         let high_card_draws = Self::high_card_for_dealer_button(lobby);
         let highest_card_team = high_card_draws[0].0.team();
@@ -39,7 +39,7 @@ impl<'a> Table<'a> {
         }
     }
 
-    fn high_card_for_dealer_button(lobby: Lobby<'a>) -> Vec<(Player, Card)> {
+    fn high_card_for_dealer_button(lobby: &Lobby<'a>) -> Vec<(Player<'a>, Card)> {
         let mut deck = Deck::new();
         deck.shuffle();
 
@@ -60,7 +60,7 @@ impl<'a> Table<'a> {
 mod tests {
     use super::*;
     use crate::game::lobby::Lobby;
-    use crate::game::{Game, Settings};
+    use crate::game::{Settings};
     use crate::user::User;
 
     fn setup_users() -> Vec<User> {
@@ -74,7 +74,7 @@ mod tests {
 
     fn setup_lobby() -> Lobby<'static> {
         let settings = Settings { to_win: 13 };
-        Game::new(settings)
+        Lobby::new(settings)
     }
 
     #[test]
@@ -83,7 +83,7 @@ mod tests {
         let mut lobby = setup_lobby();
         users.iter().for_each(|u| lobby.add_user(u));
 
-        let high_card_draws = Table::high_card_for_dealer_button(lobby);
+        let high_card_draws = Table::high_card_for_dealer_button(&lobby);
 
         let cards = high_card_draws.iter()
             .map(|(_, c)| c.clone())
@@ -104,7 +104,7 @@ mod tests {
         let mut lobby = setup_lobby();
         users.iter().for_each(|u| lobby.add_user(u));
 
-        let table = Table::new(lobby);
+        let table = Table::new(&lobby);
 
         assert_eq!(table.north.team(), table.south.team());
         assert_eq!(table.east.team(), table.west.team());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod user;
-mod game;
+pub mod game;
 mod errors;
 mod card;
 mod deck;


### PR DESCRIPTION
### Why?

API needed some refinements

### What changed?
- Lobby::new(settings) -> Lobby
- Lobby#start_game() -> Game
- Game#start_round() -> BidRound
- BidRound#register_bid() -> WinningBid (This might be changed to a PlayRound or a PassRound?)